### PR TITLE
Add hw files (*)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ kshuleshov Platform repository
 | kubernetes-vault | Kubernetes vault |
 | kubernetes-gitops| Kubernetes gitops |
 | kubernetes-storage | Kubernetes storage |
+| kubernetes-debug | Kubernetes debug |
 
 # Kubernetes networks
 ## Добавление проверок Pod
@@ -1157,3 +1158,92 @@ NAME          STATUS   VOLUME                                     CAPACITY   ACC
 storage-pvc   Bound    pvc-4aad71ca-e200-477a-9a7f-f93907e816e0   1Gi        RWO            csi-hostpath-sc   2m21s
 ```
  - `kubectl exec storage-pod -- /bin/bash -c "echo data > /data/item"`
+
+# Kubernetes debug
+## kubectl debug
+### Установите в ваш кластер kubectl debug
+ - `wget https://github.com/aylei/kubectl-debug/releases/download/v0.1.1/kubectl-debug_0.1.1_linux_amd64.tar.gz -O- | tar xz kubectl-debug && sudo mv kubectl-debug /usr/local/bin/`
+### Запустите в кластере поды с агентом kubectl-debug
+ - `kubectl apply -f https://raw.githubusercontent.com/aylei/kubectl-debug/dd7e4965e4ae5c4f53e6cf9fd17acc964274ca5c/scripts/agent_daemonset.yml`
+### Проверьте работу команды strace
+ - `kubectl apply -f kubernetes-debug/strace/web-pod.yaml`
+ - `kubectl-debug web --agentless=false --port-forward=true
+```
+strace -c -p1
+```
+```
+strace: attach: ptrace(PTRACE_SEIZE, 1): Operation not permitted
+```
+### Определите, почему не работает strace и почините
+Агент не устанавливает capabilities "SYS_PTRACE", "SYS_ADMIN". Необходимо обновить агент до последней версии.
+ - `kubernetes-debug/strace/run.sh`
+ - `kubectl-debug web --agentless=false --port-forward=true
+```
+strace -c -p1
+```
+```
+strace: Process 1 attached
+```
+## iptables-tailer
+### iptables-tailer | Тестовое приложение
+```
+kubectl apply -f https://raw.githubusercontent.com/piontec/netperf-operator/master/deploy/crd.yaml
+kubectl apply -f https://raw.githubusercontent.com/piontec/netperf-operator/master/deploy/rbac.yaml
+kubectl apply -f https://raw.githubusercontent.com/piontec/netperf-operator/master/deploy/operator.yaml
+kubectl apply -f https://raw.githubusercontent.com/piontec/netperf-operator/master/deploy/cr.yaml
+kubectl describe netperf.app.example.com/example
+```
+```
+Name:         example
+Namespace:    default
+Labels:       <none>
+Annotations:  API Version:  app.example.com/v1alpha1
+Kind:         Netperf
+Metadata:
+  Creation Timestamp:  2020-07-30T21:43:35Z
+  Generation:          4
+  Resource Version:    63437
+  Self Link:           /apis/app.example.com/v1alpha1/namespaces/default/netperfs/example
+  UID:                 696968ed-c681-4ef1-a9fc-76d0fd34f544
+Spec:
+  Client Node:
+  Server Node:
+Status:
+  Client Pod:          netperf-client-76d0fd34f544
+  Server Pod:          netperf-server-76d0fd34f544
+  Speed Bits Per Sec:  1768.9
+  Status:              Done
+Events:                <none>
+```
+### iptables-tailer | Сетевые политики
+```
+kubectl apply -f kubernetes-debug/kit/netperf-calico-policy.yaml
+kubectl delete -f https://raw.githubusercontent.com/piontec/netperf-operator/master/deploy/cr.yaml
+kubectl apply -f https://raw.githubusercontent.com/piontec/netperf-operator/master/deploy/cr.yaml
+kubectl describe netperf.app.example.com/example
+```
+```
+Status:
+  Client Pod:          netperf-client-8330b7e55db2
+  Server Pod:          netperf-server-8330b7e55db2
+  Speed Bits Per Sec:  0
+  Status:              Started test
+```
+### iptables-tailer | Установка
+ - `kubectl apply -f kubernetes-debug/kit`
+### iptables-tailes | Проверка
+```
+kubectl delete -f https://raw.githubusercontent.com/piontec/netperf-operator/master/deploy/cr.yaml
+kubectl apply -f https://raw.githubusercontent.com/piontec/netperf-operator/master/deploy/cr.yaml
+kubectl describe pod --selector=app=netperf-operator
+```
+```
+Events:
+  Type     Reason      Age   From                                               Message
+  ----     ------      ----  ----                                               -------
+  Normal   Scheduled   81s   default-scheduler                                  Successfully assigned default/netperf-server-fa66f966b976 to gke-cluster-1-default-pool-a3e69bb8-3qm4
+  Normal   Pulled      81s   kubelet, gke-cluster-1-default-pool-a3e69bb8-3qm4  Container image "tailoredcloud/netperf:v2.7" already present on machine
+  Normal   Created     80s   kubelet, gke-cluster-1-default-pool-a3e69bb8-3qm4  Created container netperf-server-fa66f966b976
+  Normal   Started     80s   kubelet, gke-cluster-1-default-pool-a3e69bb8-3qm4  Started container netperf-server-fa66f966b976
+  Warning  PacketDrop  78s   kube-iptables-tailer                               Packet dropped when receiving traffic from 10.0.1.19
+```

--- a/README.md
+++ b/README.md
@@ -1167,7 +1167,7 @@ storage-pvc   Bound    pvc-4aad71ca-e200-477a-9a7f-f93907e816e0   1Gi        RWO
  - `kubectl apply -f https://raw.githubusercontent.com/aylei/kubectl-debug/dd7e4965e4ae5c4f53e6cf9fd17acc964274ca5c/scripts/agent_daemonset.yml`
 ### Проверьте работу команды strace
  - `kubectl apply -f kubernetes-debug/strace/web-pod.yaml`
- - `kubectl-debug web --agentless=false --port-forward=true
+ - `kubectl-debug web --agentless=false --port-forward=true`
 ```
 strace -c -p1
 ```
@@ -1177,7 +1177,7 @@ strace: attach: ptrace(PTRACE_SEIZE, 1): Operation not permitted
 ### Определите, почему не работает strace и почините
 Агент не устанавливает capabilities "SYS_PTRACE", "SYS_ADMIN". Необходимо обновить агент до последней версии.
  - `kubernetes-debug/strace/run.sh`
- - `kubectl-debug web --agentless=false --port-forward=true
+ - `kubectl-debug web --agentless=false --port-forward=true`
 ```
 strace -c -p1
 ```
@@ -1230,7 +1230,12 @@ Status:
   Status:              Started test
 ```
 ### iptables-tailer | Установка
- - `kubectl apply -f kubernetes-debug/kit`
+```
+kubectl apply -f kubernetes-debug/kit/kit-clusterrole.yaml
+kubectl apply -f kubernetes-debug/kit/kit-clusterrolebinding.yaml
+kubectl apply -f kubernetes-debug/kit/kit-serviceaccount.yaml
+kubectl apply -f kubernetes-debug/kit/iptables-tailer.yaml
+```
 ### iptables-tailes | Проверка
 ```
 kubectl delete -f https://raw.githubusercontent.com/piontec/netperf-operator/master/deploy/cr.yaml
@@ -1246,4 +1251,15 @@ Events:
   Normal   Created     80s   kubelet, gke-cluster-1-default-pool-a3e69bb8-3qm4  Created container netperf-server-fa66f966b976
   Normal   Started     80s   kubelet, gke-cluster-1-default-pool-a3e69bb8-3qm4  Started container netperf-server-fa66f966b976
   Warning  PacketDrop  78s   kube-iptables-tailer                               Packet dropped when receiving traffic from 10.0.1.19
+```
+## Задание со ⭐
+### Исправьте ошибку в нашей сетевой политике, чтобы Netperf снова начал работать
+ - `kubectl apply -f kubernetes-debug/kit/netperf-calico-policy-fixed.yaml`
+### Поправьте манифест DaemonSet из репозитория, чтобы в логах отображались имена Podов, а не их IP-адреса
+```diff
+               - name: "POD_IDENTIFIER"
+-                value: "label"
+-              - name: "POD_IDENTIFIER_LABEL"
+-                value: "netperf-type"
++                value: "name"
 ```

--- a/kubernetes-debug/kit/iptables-tailer.yaml
+++ b/kubernetes-debug/kit/iptables-tailer.yaml
@@ -1,0 +1,48 @@
+---
+  apiVersion: "apps/v1"
+  kind: "DaemonSet"
+  metadata: 
+    name: "kube-iptables-tailer"
+    namespace: "kube-system"
+  spec: 
+    selector:
+      matchLabels:
+        app: "kube-iptables-tailer"
+    template:
+      metadata:
+        labels:
+          app: "kube-iptables-tailer"
+      spec: 
+        serviceAccountName: kube-iptables-tailer
+        containers: 
+          - name: "kube-iptables-tailer"
+            command:
+              - "/kube-iptables-tailer"
+              - "--log_dir=/my-service-logs" # change the output directory of service logs
+              - "--v=4" # enable V-leveled logging at this level
+            env: 
+              - name: "JOURNAL_DIRECTORY"
+                value: "/var/log/journal"
+              - name: "POD_IDENTIFIER"
+                value: "name"
+#                value: "label"
+#              - name: "POD_IDENTIFIER_LABEL"
+#                value: "netperf-type"
+              - name: "IPTABLES_LOG_PREFIX"
+                # log prefix defined in your iptables chains
+                value: "calico-packet:"
+            image: "virtualshuric/kube-iptables-tailer:8d4296a"
+            volumeMounts: 
+              - name: "iptables-logs"
+                mountPath: "/var/log"
+                readOnly: true
+              - name: "service-logs"
+                mountPath: "/my-service-logs"
+
+        volumes:
+          - name: "iptables-logs"
+            hostPath: 
+              # absolute path of the directory containing iptables log file on your host
+              path: "/var/log"
+          - name: "service-logs"
+            emptyDir: {}

--- a/kubernetes-debug/kit/kit-clusterrole.yaml
+++ b/kubernetes-debug/kit/kit-clusterrole.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-iptables-tailer
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs:     ["list","get","watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs:     ["patch","create"]

--- a/kubernetes-debug/kit/kit-clusterrolebinding.yaml
+++ b/kubernetes-debug/kit/kit-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-iptables-tailer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-iptables-tailer
+subjects:
+- kind: ServiceAccount
+  name: kube-iptables-tailer
+  namespace: kube-system

--- a/kubernetes-debug/kit/kit-serviceaccount.yaml
+++ b/kubernetes-debug/kit/kit-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-iptables-tailer
+  namespace: kube-system

--- a/kubernetes-debug/kit/netperf-calico-policy-fixed.yaml
+++ b/kubernetes-debug/kit/netperf-calico-policy-fixed.yaml
@@ -1,0 +1,20 @@
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: netperf-calico-policy
+  labels:
+spec:
+  order: 10
+  selector: app == "netperf-operator"
+  ingress:
+  - action: Allow
+    source:
+      selector: netperf-type == "client"
+  - action: Log
+  - action: Deny
+  egress:
+  - action: Allow
+    destination:
+      selector: netperf-type == "server"
+  - action: Log
+  - action: Deny

--- a/kubernetes-debug/kit/netperf-calico-policy.yaml
+++ b/kubernetes-debug/kit/netperf-calico-policy.yaml
@@ -1,0 +1,20 @@
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: netperf-calico-policy
+  labels:
+spec:
+  order: 10
+  selector: app == "netperf-operator"
+  ingress:
+  - action: Allow
+    source:
+      selector: netperf-role == "netperf-client"
+  - action: Log
+  - action: Deny
+  egress:
+  - action: Allow
+    destination:
+      selector: netperf-role == "netperf-client"
+  - action: Log
+  - action: Deny

--- a/kubernetes-debug/strace/run.sh
+++ b/kubernetes-debug/strace/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Update agent to the latest version
+kubectl apply -f https://raw.githubusercontent.com/aylei/kubectl-debug/master/scripts/agent_daemonset.yml

--- a/kubernetes-debug/strace/web-pod.yaml
+++ b/kubernetes-debug/strace/web-pod.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web
+  labels:
+    app: web
+spec:
+  containers:
+  - name: web
+    image: kshuleshov/otus-kuber-2020-04_kubernetes-intro_web
+    livenessProbe:
+      tcpSocket:
+        port: 8000
+    readinessProbe:
+      httpGet:
+        path: /index.html
+        port: 8000
+    volumeMounts:
+    - name: app
+      mountPath: /app
+  initContainers:
+  - name: init
+    image: alpine
+    command: ['sh', '-c', 'echo "Hello, world!" > /app/index.html']
+    volumeMounts:
+    - name: app
+      mountPath: /app
+  volumes:
+  - name: app
+    emptyDir: {}


### PR DESCRIPTION
# Выполнено ДЗ №

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - Установлен kubectl debug
 - Запущены поды с агентом kubectl-debug
 - Проверена работу команды strace
 - Определено, почему не работает strace и починено (агент обновлен до последней версии)
 - Установлен netperf-operator
 - Добавлены сетевые политики, блокирующие трафик Netperfr
 - Установлен  iptables-tailer
 - Проверена работа iptables-tailer
 - Исправлена ошибка в сетевой политике, чтобы Netperf снова начал работать (*)
 - Поправлен манифест DaemonSet так, чтобы в логах отображались имена Podов (*)

## kubectl debug
### Установите в ваш кластер kubectl debug
 - `wget https://github.com/aylei/kubectl-debug/releases/download/v0.1.1/kubectl-debug_0.1.1_linux_amd64.tar.gz -O- | tar xz kubectl-debug && sudo mv kubectl-debug /usr/local/bin/`
### Запустите в кластере поды с агентом kubectl-debug
 - `kubectl apply -f https://raw.githubusercontent.com/aylei/kubectl-debug/dd7e4965e4ae5c4f53e6cf9fd17acc964274ca5c/scripts/agent_daemonset.yml`
### Проверьте работу команды strace
 - `kubectl apply -f kubernetes-debug/strace/web-pod.yaml`
 - `kubectl-debug web --agentless=false --port-forward=true`
```
strace -c -p1
```
```
strace: attach: ptrace(PTRACE_SEIZE, 1): Operation not permitted
```
### Определите, почему не работает strace и почините
Агент не устанавливает capabilities "SYS_PTRACE", "SYS_ADMIN". Необходимо обновить агент до последней версии.
 - `kubernetes-debug/strace/run.sh`
 - `kubectl-debug web --agentless=false --port-forward=true`
```
strace -c -p1
```
```
strace: Process 1 attached
```
## iptables-tailer
### iptables-tailer | Тестовое приложение
```
kubectl apply -f https://raw.githubusercontent.com/piontec/netperf-operator/master/deploy/crd.yaml
kubectl apply -f https://raw.githubusercontent.com/piontec/netperf-operator/master/deploy/rbac.yaml
kubectl apply -f https://raw.githubusercontent.com/piontec/netperf-operator/master/deploy/operator.yaml
kubectl apply -f https://raw.githubusercontent.com/piontec/netperf-operator/master/deploy/cr.yaml
kubectl describe netperf.app.example.com/example
```
```
Name:         example
Namespace:    default
Labels:       <none>
Annotations:  API Version:  app.example.com/v1alpha1
Kind:         Netperf
Metadata:
  Creation Timestamp:  2020-07-30T21:43:35Z
  Generation:          4
  Resource Version:    63437
  Self Link:           /apis/app.example.com/v1alpha1/namespaces/default/netperfs/example
  UID:                 696968ed-c681-4ef1-a9fc-76d0fd34f544
Spec:
  Client Node:
  Server Node:
Status:
  Client Pod:          netperf-client-76d0fd34f544
  Server Pod:          netperf-server-76d0fd34f544
  Speed Bits Per Sec:  1768.9
  Status:              Done
Events:                <none>
```
### iptables-tailer | Сетевые политики
```
kubectl apply -f kubernetes-debug/kit/netperf-calico-policy.yaml
kubectl delete -f https://raw.githubusercontent.com/piontec/netperf-operator/master/deploy/cr.yaml
kubectl apply -f https://raw.githubusercontent.com/piontec/netperf-operator/master/deploy/cr.yaml
kubectl describe netperf.app.example.com/example
```
```
Status:
  Client Pod:          netperf-client-8330b7e55db2
  Server Pod:          netperf-server-8330b7e55db2
  Speed Bits Per Sec:  0
  Status:              Started test
```
### iptables-tailer | Установка
```
kubectl apply -f kubernetes-debug/kit/kit-clusterrole.yaml
kubectl apply -f kubernetes-debug/kit/kit-clusterrolebinding.yaml
kubectl apply -f kubernetes-debug/kit/kit-serviceaccount.yaml
kubectl apply -f kubernetes-debug/kit/iptables-tailer.yaml
```
### iptables-tailes | Проверка
```
kubectl delete -f https://raw.githubusercontent.com/piontec/netperf-operator/master/deploy/cr.yaml
kubectl apply -f https://raw.githubusercontent.com/piontec/netperf-operator/master/deploy/cr.yaml
kubectl describe pod --selector=app=netperf-operator
```
```
Events:
  Type     Reason      Age   From                                               Message
  ----     ------      ----  ----                                               -------
  Normal   Scheduled   81s   default-scheduler                                  Successfully assigned default/netperf-server-fa66f966b976 to gke-cluster-1-default-pool-a3e69bb8-3qm4
  Normal   Pulled      81s   kubelet, gke-cluster-1-default-pool-a3e69bb8-3qm4  Container image "tailoredcloud/netperf:v2.7" already present on machine
  Normal   Created     80s   kubelet, gke-cluster-1-default-pool-a3e69bb8-3qm4  Created container netperf-server-fa66f966b976
  Normal   Started     80s   kubelet, gke-cluster-1-default-pool-a3e69bb8-3qm4  Started container netperf-server-fa66f966b976
  Warning  PacketDrop  78s   kube-iptables-tailer                               Packet dropped when receiving traffic from 10.0.1.19
```
## Задание со ⭐
### Исправьте ошибку в нашей сетевой политике, чтобы Netperf снова начал работать
 - `kubectl apply -f kubernetes-debug/kit/netperf-calico-policy-fixed.yaml`
### Поправьте манифест DaemonSet из репозитория, чтобы в логах отображались имена Podов, а не их IP-адреса
```diff
               - name: "POD_IDENTIFIER"
-                value: "label"
-              - name: "POD_IDENTIFIER_LABEL"
-                value: "netperf-type"
+                value: "name"
```
## PR checklist:
 - [x] Выставлен label с темой домашнего задания
